### PR TITLE
Name for programms

### DIFF
--- a/kks/cmd/sync.py
+++ b/kks/cmd/sync.py
@@ -43,7 +43,7 @@ def sync():
 
         task_dir.mkdir(parents=True, exist_ok=True)
 
-        main = task_dir / 'main.c'
+        main = task_dir / f'{problem.short_name}.c'
         main.touch()
 
         gen = task_dir / 'gen.py'


### PR DESCRIPTION
При выборе файла программы в контесте отображается только название `main.c`, поэтому, чтобы избежать случайного выбора другой программы, сделал индивидуальное название для файла.