### PR TITLE
Добавлено (ограниченное) автоопределение типов файлов при синхронизации посылок

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='kokos',
     description='KoKoS helper tool',
     author='Vyacheslav Boben',
-    version='1.2.1',
+    version='1.2.2',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Прошлая версия команды "kks sync --code" сохраняла все посылки с расширением ".c"
Теперь должны корректно определяться сжатые с помощью gzip файлы (см. sm01/3) и некоторые стандартные типы файлов (которые распознаются с помощью mimetypes).
Если ejudge не возвращает заголовок "Content-type" (предположительно, этого никогда не происходит), то файл сохраняется без расширения