### PR TITLE
fix indent for styled text in markdown tables

### DIFF
--- a/kks/util/h2t.py
+++ b/kks/util/h2t.py
@@ -145,6 +145,8 @@ class HTML2Text(html2text.HTML2Text):
                 self.headless_table = True
                 self.table_start = False
             self.o("| ")
+            self.preceding_data = " "
+            self.preceding_stressed = False
 # ====================!modified====================
 
         if tag == "tr" and start:
@@ -152,7 +154,7 @@ class HTML2Text(html2text.HTML2Text):
         if tag == "tr" and not start:
 # ====================modified====================
             if self.headless_table:
-                # restore old textlost
+                # restore old textlist
                 tr_textlist = self.outtextlist
                 self.outtextlist = self.main_outtextlist
                 del self.main_outtextlist

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description_content_type='text/markdown',
     author='Vyacheslav Boben',
     url='https://github.com/DarkKeks/kks',
-    version='1.6.3',
+    version='1.6.4',
     packages=find_packages(),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
Оригинальный код html2text может добавлять лишние пробелы перед жирным/курсивным/... текстом в таблицах. Из-за этого таблицы с ограничениями в исходниках условий выглядели криво